### PR TITLE
Allow unmodified click without drag to narrow selection to a single row

### DIFF
--- a/table.go
+++ b/table.go
@@ -812,10 +812,10 @@ func (t *Table[T]) DefaultMouseDrag(where Point, button int, mod Modifiers) bool
 
 // DefaultMouseUp provides the default mouse up handling.
 func (t *Table[T]) DefaultMouseUp(where Point, button int, mod Modifiers) bool {
-	time_elapsed := int64(time.Since(t.lastClick.t))
-	time_elapsed = time_elapsed / int64(time.Millisecond)
+	timeElapsed := int64(time.Since(t.lastClick.t))
+	timeElapsed = timeElapsed / int64(time.Millisecond)
 
-	if button == ButtonLeft && time_elapsed < 75 {
+	if button == ButtonLeft && timeElapsed < 75 {
 		t.ClearSelection()
 		t.selMap[t.lastClick.id] = true
 		t.MarkForRedraw()


### PR DESCRIPTION

Allow select one from current selection with click
- Creates type lastClick, which records time and row of last click
- Updates lastClick when shift is not held down while clicking on an
already selected row.
- DefaultMouseUp checks if lastClick was near in time (currently 75
milliseconds). If so, it selects only the clicked row.