### PR TITLE
Add support for drawing glyph runs with x positions

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -236,6 +236,11 @@ func (c *Canvas) DrawSimpleString(str string, x, y float32, font Font, paint *Pa
 	}
 }
 
+// DrawTextBlob draws text from a text blob.
+func (c *Canvas) DrawTextBlob(blob TextBlob, x, y float32, paint *Paint) {
+	skia.CanvasDrawTextBlob(c.canvas, blob.TextBlob, x, y, paint.paint)
+}
+
 // ClipRect replaces the clip with the intersection of difference of the current clip and rect.
 func (c *Canvas) ClipRect(rect Rect, op ClipOp, antialias bool) {
 	skia.CanavasClipRectWithOperation(c.canvas, skia.RectToSkRect(&rect), skia.ClipOp(op), antialias)

--- a/canvas.go
+++ b/canvas.go
@@ -237,7 +237,7 @@ func (c *Canvas) DrawSimpleString(str string, x, y float32, font Font, paint *Pa
 }
 
 // DrawTextBlob draws text from a text blob.
-func (c *Canvas) DrawTextBlob(blob TextBlob, x, y float32, paint *Paint) {
+func (c *Canvas) DrawTextBlob(blob *TextBlob, x, y float32, paint *Paint) {
 	skia.CanvasDrawTextBlob(c.canvas, blob.TextBlob, x, y, paint.paint)
 }
 

--- a/dynamic_font.go
+++ b/dynamic_font.go
@@ -85,6 +85,10 @@ func (f *DynamicFont) Descriptor() FontDescriptor {
 	return f.resolvedFont().Descriptor()
 }
 
+func (f *DynamicFont) TextBlobPosH(glyphs []uint16, positions []float32, y float32) TextBlob {
+	return f.resolvedFont().TextBlobPosH(glyphs, positions, y)
+}
+
 func (f *DynamicFont) skiaFont() skia.Font {
 	return f.resolvedFont().skiaFont()
 }

--- a/dynamic_font.go
+++ b/dynamic_font.go
@@ -85,7 +85,7 @@ func (f *DynamicFont) Descriptor() FontDescriptor {
 	return f.resolvedFont().Descriptor()
 }
 
-func (f *DynamicFont) TextBlobPosH(glyphs []uint16, positions []float32, y float32) TextBlob {
+func (f *DynamicFont) TextBlobPosH(glyphs []uint16, positions []float32, y float32) *TextBlob {
 	return f.resolvedFont().TextBlobPosH(glyphs, positions, y)
 }
 

--- a/font.go
+++ b/font.go
@@ -74,7 +74,7 @@ type Font interface {
 	SimpleWidth(str string) float32
 	// TextBlobPosH creates a text blob for glyphs, with specified horizontal positions.
 	// The glyphs and positions slices should have the same length.
-	TextBlobPosH(glyphs []uint16, positions []float32, y float32) TextBlob
+	TextBlobPosH(glyphs []uint16, positions []float32, y float32) *TextBlob
 	// Descriptor returns a FontDescriptor for this Font.
 	Descriptor() FontDescriptor
 	skiaFont() skia.Font
@@ -164,12 +164,12 @@ func (f *fontImpl) SimpleWidth(str string) float32 {
 	return skia.FontMeasureText(f.font, str)
 }
 
-func (f *fontImpl) TextBlobPosH(glyphs []uint16, positions []float32, y float32) TextBlob {
+func (f *fontImpl) TextBlobPosH(glyphs []uint16, positions []float32, y float32) *TextBlob {
 	builder := skia.TextBlobBuilderNew()
 	skia.TextBlobBuilderAllocRunPosH(builder, f.font, glyphs, positions, y)
 	blob := skia.TextBlobBuilderMake(builder)
 	skia.TextBlobBuilderDelete(builder)
-	return *newTextBlob(blob)
+	return newTextBlob(blob)
 }
 
 func (f *fontImpl) skiaFont() skia.Font {

--- a/font.go
+++ b/font.go
@@ -72,6 +72,9 @@ type Font interface {
 	// SimpleWidth returns the width of a string. It does not do font fallback, nor does it consider tabs or line
 	// endings.
 	SimpleWidth(str string) float32
+	// TextBlobPosH creates a text blob for glyphs, with specified horizontal positions.
+	// The glyphs and positions slices should have the same length.
+	TextBlobPosH(glyphs []uint16, positions []float32, y float32) TextBlob
 	// Descriptor returns a FontDescriptor for this Font.
 	Descriptor() FontDescriptor
 	skiaFont() skia.Font
@@ -159,6 +162,14 @@ func (f *fontImpl) SimpleWidth(str string) float32 {
 		return 0
 	}
 	return skia.FontMeasureText(f.font, str)
+}
+
+func (f *fontImpl) TextBlobPosH(glyphs []uint16, positions []float32, y float32) TextBlob {
+	builder := skia.TextBlobBuilderNew()
+	skia.TextBlobBuilderAllocRunPosH(builder, f.font, glyphs, positions, y)
+	blob := skia.TextBlobBuilderMake(builder)
+	skia.TextBlobBuilderDelete(builder)
+	return *newTextBlob(blob)
 }
 
 func (f *fontImpl) skiaFont() skia.Font {

--- a/indirect_font.go
+++ b/indirect_font.go
@@ -75,6 +75,10 @@ func (f *IndirectFont) Descriptor() FontDescriptor {
 	return f.Font.Descriptor()
 }
 
+func (f *IndirectFont) TextBlobPosH(glyphs []uint16, positions []float32, y float32) TextBlob {
+	return f.Font.TextBlobPosH(glyphs, positions, y)
+}
+
 func (f *IndirectFont) skiaFont() skia.Font {
 	return f.Font.skiaFont()
 }

--- a/indirect_font.go
+++ b/indirect_font.go
@@ -75,7 +75,7 @@ func (f *IndirectFont) Descriptor() FontDescriptor {
 	return f.Font.Descriptor()
 }
 
-func (f *IndirectFont) TextBlobPosH(glyphs []uint16, positions []float32, y float32) TextBlob {
+func (f *IndirectFont) TextBlobPosH(glyphs []uint16, positions []float32, y float32) *TextBlob {
 	return f.Font.TextBlobPosH(glyphs, positions, y)
 }
 

--- a/internal/skia/skia_other.go
+++ b/internal/skia/skia_other.go
@@ -1217,6 +1217,12 @@ func TextBlobBuilderAllocRun(builder TextBlobBuilder, font Font, glyphs []uint16
 	copy(((*[1 << 30]uint16)(unsafe.Pointer(buffer.glyphs)))[:len(glyphs)], glyphs)
 }
 
+func TextBlobBuilderAllocRunPosH(builder TextBlobBuilder, font Font, glyphs []uint16, positions []float32, y float32) {
+	buffer := C.sk_textblob_builder_alloc_run_pos_h(builder, font, C.int(len(glyphs)), C.float(y), nil)
+	copy(((*[1 << 30]uint16)(unsafe.Pointer(buffer.glyphs)))[:len(glyphs)], glyphs)
+	copy(((*[1 << 30]float32)(unsafe.Pointer(buffer.pos)))[:len(positions)], positions)
+}
+
 func TextBlobBuilderDelete(builder TextBlobBuilder) {
 	C.sk_textblob_builder_delete(builder)
 }

--- a/internal/skia/skia_windows.go
+++ b/internal/skia/skia_windows.go
@@ -303,6 +303,15 @@ var (
 	skTypeFaceUnrefProc                       *syscall.Proc
 )
 
+// textBlobBuilderRunBuffer supplies storage for glyphs and positions within a run.
+// It has the same layout as skia's SkTextBlobBuilder::RunBuffer type.
+type textBlobBuilderRunBuffer struct {
+	Glyphs   unsafe.Pointer
+	Pos      unsafe.Pointer
+	UTF8Text unsafe.Pointer
+	Clusters unsafe.Pointer
+}
+
 func init() {
 	dir, err := os.UserCacheDir()
 	jot.FatalIfErr(err)
@@ -1942,12 +1951,6 @@ func TextBlobBuilderMake(builder TextBlobBuilder) TextBlob {
 }
 
 func TextBlobBuilderAllocRun(builder TextBlobBuilder, font Font, glyphs []uint16, x, y float32) {
-	type textBlobBuilderRunBuffer struct {
-		Glyphs   unsafe.Pointer
-		Pos      unsafe.Pointer
-		UTF8Text unsafe.Pointer
-		Clusters unsafe.Pointer
-	}
 	r1, _, _ := skTextBlobBuilderAllocRunProc.Call(uintptr(builder), uintptr(font), uintptr(len(glyphs)),
 		uintptr(math.Float32bits(x)), uintptr(math.Float32bits(y)), 0)
 	buffer := (*textBlobBuilderRunBuffer)(unsafe.Pointer(r1))
@@ -1955,12 +1958,6 @@ func TextBlobBuilderAllocRun(builder TextBlobBuilder, font Font, glyphs []uint16
 }
 
 func TextBlobBuilderAllocRunPosH(builder TextBlobBuilder, font Font, glyphs []uint16, positions []float32, y float32) {
-	type textBlobBuilderRunBuffer struct {
-		Glyphs   unsafe.Pointer
-		Pos      unsafe.Pointer
-		UTF8Text unsafe.Pointer
-		Clusters unsafe.Pointer
-	}
 	r1, _, _ := skTextBlobBuilderAllocRunPosHProc.Call(uintptr(builder), uintptr(font), uintptr(len(glyphs)),
 		uintptr(math.Float32bits(y)), 0)
 	buffer := (*textBlobBuilderRunBuffer)(unsafe.Pointer(r1))

--- a/internal/skia/skia_windows.go
+++ b/internal/skia/skia_windows.go
@@ -1954,6 +1954,20 @@ func TextBlobBuilderAllocRun(builder TextBlobBuilder, font Font, glyphs []uint16
 	copy(((*[1 << 30]uint16)(unsafe.Pointer(buffer.Glyphs)))[:len(glyphs)], glyphs)
 }
 
+func TextBlobBuilderAllocRunPosH(builder TextBlobBuilder, font Font, glyphs []uint16, positions []float32, y float32) {
+	type textBlobBuilderRunBuffer struct {
+		Glyphs   unsafe.Pointer
+		Pos      unsafe.Pointer
+		UTF8Text unsafe.Pointer
+		Clusters unsafe.Pointer
+	}
+	r1, _, _ := skTextBlobBuilderAllocRunPosHProc.Call(uintptr(builder), uintptr(font), uintptr(len(glyphs)),
+		uintptr(math.Float32bits(y)), 0)
+	buffer := (*textBlobBuilderRunBuffer)(unsafe.Pointer(r1))
+	copy(((*[1 << 30]uint16)(unsafe.Pointer(buffer.Glyphs)))[:len(glyphs)], glyphs)
+	copy(((*[1 << 30]uint16)(unsafe.Pointer(buffer.Pos)))[:len(positions)], positions)
+}
+
 func TextBlobBuilderDelete(builder TextBlobBuilder) {
 	skTextBlobBuilderDeleteProc.Call(uintptr(builder))
 }

--- a/text_blob.go
+++ b/text_blob.go
@@ -1,0 +1,25 @@
+package unison
+
+import (
+	"runtime"
+
+	"github.com/richardwilkes/unison/internal/skia"
+)
+
+// TextBlob represents runs of text for a font, that may be drawn on a Canvas.
+type TextBlob struct {
+	skia.TextBlob
+}
+
+func newTextBlob(textBlob skia.TextBlob) *TextBlob {
+	if textBlob == nil {
+		return nil
+	}
+	tb := &TextBlob{TextBlob: textBlob}
+	runtime.SetFinalizer(tb, func(obj *TextBlob) {
+		ReleaseOnUIThread(func() {
+			skia.TextBlobUnref(tb.TextBlob)
+		})
+	})
+	return tb
+}


### PR DESCRIPTION
I needed to be able to draw runs of glyphs with specific horizontal positions.

New api functions
- `Font.TextBlobPosH` to create a `TextBlob` with horizontally positioned glyphs
- `Canvas.DrawTextBlob` to draw text from a blob

The Windows implementation of `TextBlobBuilderAllocRunPosH` is untested, as I don't have a Windows environment. I wrote it  following a similar  pattern to the existing `TextBlobBuilderAllocRun` function.