### PR TITLE
Fix display issue with initial nil value

### DIFF
--- a/combo_field.go
+++ b/combo_field.go
@@ -78,8 +78,10 @@ func NewComboField(options []*string, initial *string, changedCallback func(valu
 		}
 	}
 	updating := false
+	initialized := false
 	setDisplay := func(value *string) {
-		if !matchesCurrent(value) {
+		if !initialized || !matchesCurrent(value) {
+			initialized = true
 			updating = true
 			currentValue = value
 			switch {

--- a/combo_field.go
+++ b/combo_field.go
@@ -78,11 +78,11 @@ func NewComboField(options []*string, initial *string, changedCallback func(valu
 		}
 	}
 	updating := false
-	initialized := false
+	fieldValueSet := false
 	setDisplay := func(value *string) {
-		if !initialized || !matchesCurrent(value) {
-			initialized = true
+		if !fieldValueSet || !matchesCurrent(value) {
 			updating = true
+			fieldValueSet = true
 			currentValue = value
 			switch {
 			case value == nil:


### PR DESCRIPTION
The widget didn't detect an initial value of nil as a change and skipped rendering the unset marker as a result.